### PR TITLE
Improve start-up time by deferring slow imports.

### DIFF
--- a/configurator/config.py
+++ b/configurator/config.py
@@ -16,8 +16,7 @@ class Config(ConfigNode):
     """
 
     __slots__ = ('data', '_previous')
-
-    parsers = Parsers.from_entrypoints()
+    parsers = None
 
     def __init__(self, data=None):
         super(Config, self).__init__(data)
@@ -51,6 +50,11 @@ class Config(ConfigNode):
                 except ValueError:
                     pass
         if not callable(parser):
+            # Loading the parsers takes a long time (≈200 ms) because it causes 
+            # a lot of code to be imported (`pkg_resources`, `toml`, `yaml`, 
+            # etc).  So don't load the parsers until just before we need them.
+            if cls.parsers is None:
+                cls.parsers = Parsers.from_entrypoints()
             parser = cls.parsers.get(parser)
         return cls(parser(stream))
 

--- a/configurator/config.py
+++ b/configurator/config.py
@@ -1,5 +1,4 @@
 import os
-from copy import deepcopy
 from io import open, StringIO
 from os.path import exists, expanduser
 
@@ -160,6 +159,7 @@ class Config(ConfigNode):
         if empty:
             base = Config()
         else:
+            from copy import deepcopy
             base = Config(deepcopy(self.data))
         if not isinstance(config, Config):
             config = Config(config)

--- a/configurator/node.py
+++ b/configurator/node.py
@@ -1,5 +1,3 @@
-from pprint import pformat
-
 
 class ConfigNode(object):
     """
@@ -81,6 +79,7 @@ class ConfigNode(object):
             yield self._wrap(item)
 
     def __repr__(self):
+        from pprint import pformat
         cls = type(self)
         pretty = pformat(self.data, width=70)
         if '\n' in pretty:

--- a/configurator/parsers.py
+++ b/configurator/parsers.py
@@ -1,5 +1,3 @@
-from pkg_resources import iter_entry_points
-
 
 class ParseError(Exception):
     """
@@ -12,6 +10,9 @@ class Parsers(dict):
     
     @classmethod
     def from_entrypoints(cls):
+        # `pkg_resources` is slow to import, so defer until we need it.
+        from pkg_resources import iter_entry_points
+
         parsers = cls()
         for entrypoint in iter_entry_points(group='configurator.parser'):
             try:


### PR DESCRIPTION
The `configurator` package takes 200-300 ms to import, which is enough to cause a noticeable pause when a program is starting up.  Almost all of this time is spent importing `pkg_resources`:

```console
$ python -X importtime -c 'import configurator'
$ python -X importtime -c 'import pkg_resources'
```

By deferring this import until it is needed, `configurator` can start up in about 7 ms—much faster.  This is really nice if the command being executed doesn't actually need to read a config file, e.g. if it's just displaying usage help or something.