### PR TITLE
support delattr

### DIFF
--- a/configurator/config.py
+++ b/configurator/config.py
@@ -179,7 +179,7 @@ class Config(ConfigNode):
         self.data = self._previous.pop()
 
 
-class PushContext(object):
+class PushContext:
 
     def __init__(self, config, data):
         self.config = config

--- a/configurator/merge.py
+++ b/configurator/merge.py
@@ -34,7 +34,7 @@ default_mergers = MergeableDict({
 })
 
 
-class MergeContext(object):
+class MergeContext:
 
     mergers = default_mergers
 

--- a/configurator/node.py
+++ b/configurator/node.py
@@ -3,7 +3,7 @@ from pprint import pformat
 from .path import parse_text, NotPresent
 
 
-class ConfigNode(object):
+class ConfigNode:
     """
     A node in the configuration store.
     These are obtained by using the methods below on :class:`~configurator.Config`

--- a/configurator/node.py
+++ b/configurator/node.py
@@ -55,6 +55,17 @@ class ConfigNode:
         else:
             self[name] = value
 
+    def __delattr__(self, name):
+        """
+        Remove a child of this node by attribute access. This is a convenience
+        helper that calls :meth:`__delitem__` and can be used when ``name`` is
+        a string.
+        """
+        try:
+            del self[name]
+        except KeyError:
+            raise AttributeError(name)
+
     def __getitem__(self, name):
         """
         Obtain a child of this node by item access. If the child
@@ -70,6 +81,14 @@ class ConfigNode:
         If :attr:`data` is a :class:`list`, then ``name`` must be an :class:`int`.
         """
         self.data[name] = value
+
+    def __delitem__(self, name):
+        """
+        Remove the supplied ``name`` in :attr:`data`.
+        If :attr:`data` is a :class:`dict`, then ``name`` must be a :class:`str`.
+        If :attr:`data` is a :class:`list`, then ``name`` must be an :class:`int`.
+        """
+        del self.data[name]
 
     def get(self, name=None, default=None):
         """

--- a/configurator/path.py
+++ b/configurator/path.py
@@ -1,7 +1,7 @@
 class NotPresent(Exception): pass
 
 
-class Op(object):
+class Op:
 
     name = 'op'
 
@@ -208,7 +208,7 @@ class ValueOp(Op):
         return '{}({!r})'.format(self.name, self.value)
 
 
-class Path(object):
+class Path:
     """
     A generative object used for constructing source or target mappings.
     See :doc:`mapping` for details.

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,4 @@
 import linecache
-import sys
 import tokenize
 from doctest import REPORT_NDIFF, ELLIPSIS
 
@@ -10,6 +9,7 @@ from sybil.parsers.doctest import DocTestParser
 from sybil.parsers.codeblock import PythonCodeBlockParser
 from testfixtures import Replacer, TempDirectory
 from testfixtures.sybil import FileParser
+
 
 @pytest.fixture(scope='module')
 def fs_state():

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 # See license.txt for license details.
 # Copyright (c) 2011-2014 Simplistix Ltd, 2016-2022 Chris Withers
-
-import os
-
 from setuptools import setup, find_packages
-
-base_dir = os.path.dirname(__file__)
 
 setup(
     name='configurator',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ def python_literal(stream):
     return literal_eval(stream.read())
 
 
-class TestInstantiation(object):
+class TestInstantiation:
 
     def test_empty(self):
         config = Config()
@@ -179,7 +179,7 @@ class TestInstantiation(object):
         compare(config.data, expected={})
 
 
-class TestPushPop(object):
+class TestPushPop:
 
     def test_push_pop(self):
         config = Config({'x': 1, 'y': 2})
@@ -252,7 +252,7 @@ class TestPushPop(object):
         compare(config.x.y, expected='z')
 
 
-class TestNodeBehaviour(object):
+class TestNodeBehaviour:
 
     def test_dict_access(self):
         config = Config({'foo': 'bar'})
@@ -268,7 +268,7 @@ class TestNodeBehaviour(object):
         compare(config.get('merge'), expected=True)
 
 
-class TestMergeTests(object):
+class TestMergeTests:
 
     def test_empty_config(self):
         config = Config()
@@ -469,7 +469,7 @@ class TestMergeTests(object):
         assert config.data['list'][1] is not config_.data['list'][1]
 
 
-class TestAddition(object):
+class TestAddition:
 
     def test_top_level_dict(self):
         config1 = Config({'foo': 'bar'})
@@ -498,7 +498,7 @@ class TestAddition(object):
             Config({'foo': 'bar'}) + 1
 
 
-class TestSerialization(object):
+class TestSerialization:
 
     def test_pickle_default_protocol(self):
         config = Config({'foo': [1, 2]})

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -6,7 +6,7 @@ from configurator.mapping import target, convert
 import pytest
 
 
-class TestFunctional(object):
+class TestFunctional:
 
     def test_layered(self, dir):
         # defaults

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -6,7 +6,7 @@ from configurator.merge import MergeContext
 from configurator.path import NotPresent
 
 
-class TestSource(object):
+class TestSource:
 
     def test_root(self):
         data = {'foo'}
@@ -167,7 +167,7 @@ class TestSource(object):
         compare(load({}, if_supplied(value(None))), expected=NotPresent(None))
 
 
-class TestTarget(object):
+class TestTarget:
 
     def test_root(self):
         data = {'foo'}

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -7,7 +7,7 @@ from configurator.node import ConfigNode
 from configurator.path import NotPresent
 
 
-class TestInstantiation(object):
+class TestInstantiation:
 
     def test_empty(self):
         config = ConfigNode()
@@ -29,7 +29,7 @@ class TestInstantiation(object):
         compare(config.data, 1)
 
 
-class TestItemAccess(object):
+class TestItemAccess:
 
     def test_there_dict(self):
         config = ConfigNode({'foo': 1})
@@ -123,7 +123,7 @@ class TestItemAccess(object):
         compare(config.data, expected=['new'])
 
 
-class TestAttributeAccess(object):
+class TestAttributeAccess:
 
     def test_there(self):
         config = ConfigNode({'foo': 1})
@@ -177,7 +177,7 @@ class TestAttributeAccess(object):
         compare(config.data, expected=[])
 
 
-class TestOtherFunctionality(object):
+class TestOtherFunctionality:
 
     def test_iterate_over_list_of_dicts(self):
         node = ConfigNode([{'x': 1}])
@@ -204,7 +204,7 @@ class TestOtherFunctionality(object):
             )"""))
 
 
-class TestNodeActions(object):
+class TestNodeActions:
 
     def test_attr_dict(self):
         node = ConfigNode({'a': {'b': 1}})

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -122,6 +122,26 @@ class TestItemAccess:
         config[0] = 'new'
         compare(config.data, expected=['new'])
 
+    def test_remove_dict(self):
+        config = ConfigNode({'foo': 1})
+        del config['foo']
+        compare(config.data, expected={})
+
+    def test_remove_not_there_dict(self):
+        config = ConfigNode({'foo': 1})
+        with ShouldRaise(KeyError('bar')):
+            del config['bar']
+
+    def test_remove_list(self):
+        config = ConfigNode(["x", "y"])
+        del config[0]
+        compare(config.data, expected=["y"])
+
+    def test_remove_not_there_list(self):
+        config = ConfigNode(["x", "y"])
+        with ShouldRaise(IndexError('list assignment index out of range')):
+            del config[2]
+
 
 class TestAttributeAccess:
 
@@ -175,6 +195,16 @@ class TestAttributeAccess:
         with ShouldRaise(TypeError):
             config.foo = 1
         compare(config.data, expected=[])
+
+    def test_del_attr(self):
+        config = ConfigNode({"foo": 1})
+        del config.foo
+        compare(config.data, expected={})
+
+    def test_del_attr_not_there_dict(self):
+        config = ConfigNode({"foo": 1})
+        with ShouldRaise(AttributeError("bar")):
+            del config.bar
 
 
 class TestOtherFunctionality:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -4,7 +4,7 @@ from configurator.mapping import source, target, required, convert, value
 from configurator.path import parse_text
 
 
-class TestPaths(object):
+class TestPaths:
 
     def test_repr(self):
         compare(repr(source), expected="Path:source")

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -6,7 +6,7 @@ from configurator import Config
 from configurator.patterns import load_with_extends
 
 
-class TestLoadWithExtends(object):
+class TestLoadWithExtends:
 
     def test_key_not_present(self, dir):
         path = dir.write('file.json', '{"key":"value"}')


### PR DESCRIPTION
When attempting to replace the global configuration container in a big and old project (which was using an [`optparse.Values`](https://github.com/python/cpython/blob/v3.11.0/Lib/optparse.py#L823-L885)-like thing), we got bitten by this:

```
>>> cfg = Config(data={"foo": 1, "bar": 2})
>>> hasattr(cfg, "foo")
True
>>> delattr(cfg, "foo")
AttributeError: 'Config' object has no attribute 'foo'
```

This PR adds support for deletion.